### PR TITLE
Solve: [Log RGB image to wandb instead of RGBA #11](https://github.com/PhilipMathieu/unet-orthoimagery/issues/11)

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -148,14 +148,12 @@ def train_model(
                         
                         val_score = evaluate(model, val_loader, device, amp)
                         scheduler.step(val_score)
-                        print()
-                        print(f'images.shape: {images.shape}')
                         logging.info('Validation Dice score: {}'.format(val_score))
                         try:
                             experiment.log({
                                 'learning rate': optimizer.param_groups[0]['lr'],
                                 'validation Dice': val_score,
-                                'images': wandb.Image(images[0][:3,:,:].cpu()),
+                                'images': wandb.Image(images[0][:3,:,:].cpu()), # Log only RGB
                                 'masks':{
                                     'true': wandb.Image(true_masks[0].float().cpu()),
                                     'pred': wandb.Image((F.sigmoid(masks_pred[0]).squeeze(1) > 0.5).float().cpu()),

--- a/src/train.py
+++ b/src/train.py
@@ -148,13 +148,14 @@ def train_model(
                         
                         val_score = evaluate(model, val_loader, device, amp)
                         scheduler.step(val_score)
-
+                        print()
+                        print(f'images.shape: {images.shape}')
                         logging.info('Validation Dice score: {}'.format(val_score))
                         try:
                             experiment.log({
                                 'learning rate': optimizer.param_groups[0]['lr'],
                                 'validation Dice': val_score,
-                                'images': wandb.Image(images[0].cpu()),
+                                'images': wandb.Image(images[0][:3,:,:].cpu()),
                                 'masks':{
                                     'true': wandb.Image(true_masks[0].float().cpu()),
                                     'pred': wandb.Image((F.sigmoid(masks_pred[0]).squeeze(1) > 0.5).float().cpu()),


### PR DESCRIPTION
Solve: [Log RGB image to wandb instead of RGBA #11](https://github.com/PhilipMathieu/unet-orthoimagery/issues/11)